### PR TITLE
Fixing face_match bug

### DIFF
--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -122,7 +122,7 @@ void face_match(ComMod& com_mod, faceType& lFa, faceType& gFa, Vector<int>& ptr)
     blk[iBlk].n = blk[iBlk].n + 1;
   }
 
-  for (int a = 0; a < gFa.nNo; a++) {
+  for (int a = 0; a < lFa.nNo; a++) {
     auto coord = lFa.x.col(a);
     int iBlk = find_blk(nsd, nBlkd, nFlt, xMin, dx, coord);
     auto minS = std::numeric_limits<double>::max();


### PR DESCRIPTION
Fixing face match bug #323 

## Current situation
The code generated a segmentation fault type error when setting a traction boundary condition type. 

## Release Notes 
Changed line 126 in face_match function to loop over lFa.nNo instead gFA.nNo

## Testing
No test required

## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
