### PR TITLE
Check on the flux profile type name #322

### DIFF
--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -416,6 +416,8 @@ void read_bc(Simulation* simulation, EquationParameters* eq_params, eqType& lEq,
     int iFa = lBc.iFa;
 
     read_spatial_values(com_mod, com_mod.msh[iM], com_mod.msh[iM].fa[iFa], file_name, lBc);
+  } else {
+    throw std::runtime_error("[read_bc] Unknown spatial profile type '" + ctmp + "'.");
   }
 
   // Weak Dirichlet BC for fluid/FSI equations


### PR DESCRIPTION
## Current situation
The flux profile type names accepted by the solver are: "Flat", "Parabolic" and "User_defined" (case sensitive). If the name on the input file does not match, no error is provided and eventually the simulation will crash with a non-related error.

## Release Notes 
A check is added and a descriptive runtime error will be prompt whenever a match is not found in the profile type name.

## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
