### PR TITLE
Fix bug with coupled BCs in FSI simulation

### DIFF
--- a/Code/Source/solver/set_bc.cpp
+++ b/Code/Source/solver/set_bc.cpp
@@ -84,8 +84,7 @@ void calc_der_cpl_bc(ComMod& com_mod, const CmMod& cm_mod)
   // if (ALL(cplBC.fa.bGrp .EQ. cplBC_Dir)) RETURN
 
   // Determine current physics
-  auto& cDmn = com_mod.cDmn;
-  auto cPhys = eq.dmn[cDmn].phys;
+  auto cPhys = eq.phys;
 
   // Mechanical configuration in which to compute flowrate
   auto cfg_o = MechanicalConfigurationType::reference;
@@ -686,8 +685,7 @@ void set_bc_cpl(ComMod& com_mod, CmMod& cm_mod)
   auto& eq = com_mod.eq[iEq];
 
   // Determine current physics
-  auto& cDmn = com_mod.cDmn;
-  auto cPhys = eq.dmn[cDmn].phys;
+  auto cPhys = eq.phys;
 
   // Configuration in which to compute flowrate
   auto cfg_o = MechanicalConfigurationType::reference;

--- a/tests/cases/fsi/pipe_RCR_3d/README.md
+++ b/tests/cases/fsi/pipe_RCR_3d/README.md
@@ -1,4 +1,3 @@
 
 # **Problem Description**
-
 Same as pipe_3d, but uses RCR boundary condition on lumen_outlet.

--- a/tests/cases/fsi/pipe_RCR_3d/README.md
+++ b/tests/cases/fsi/pipe_RCR_3d/README.md
@@ -1,0 +1,4 @@
+
+# **Problem Description**
+
+Same as pipe_3d, but uses RCR boundary condition on lumen_outlet.

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-complete.mesh.vtu
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-complete.mesh.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bff21b54094fe528e6f7cd9b57dafc5863b530e112e08f8a62a04431ec14a7a3
+size 67969

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/end.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/end.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57511367796bab30c07b3b5dbd3b6ec596e433cb1aae2afe763f05ab357655bf
+size 13661

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/interface.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/interface.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c4a25e331d2c3ccbfa2ffcdd52e0ebbd37a8045989bec9abd7b2c0ed775e2b8
+size 28724

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/start.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/fluid/mesh-surfaces/start.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d90d5fb5ce21d0889b27fd0a592aafa6121d19047bebd801710caf5cba6fb48a
+size 13685

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-complete.mesh.vtu
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-complete.mesh.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2527472b08ece18c95175c0661ca838f90ac8b97406d0c1c77459e94df620fe7
+size 36980

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/end.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/end.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abb10cc3c374742b481031050fd6ceb2af30b8a14bd5627d89f930a4df01708a
+size 12351

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/interface.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/interface.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9302a80f392f30ae07b98d0048cb7ad85f2fd3fcb0a86dbe50def69ba5a6cafc
+size 28900

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/outside.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/outside.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29c18dc6c30b33a98016c3df4038433430307f05bc5fd3d2d39469b4a3d4bb63
+size 28813

--- a/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/start.vtp
+++ b/tests/cases/fsi/pipe_RCR_3d/mesh/solid/mesh-surfaces/start.vtp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c679e42882a1a2db6382133d896879e84468058870863e670fc31212d4e29c2
+size 12335

--- a/tests/cases/fsi/pipe_RCR_3d/result_005.vtu
+++ b/tests/cases/fsi/pipe_RCR_3d/result_005.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96844a0415f7d2d969d75bd9c204c5f555bbcf07e43883b23a8c4a4ecf83a045
+size 209837

--- a/tests/cases/fsi/pipe_RCR_3d/solver.xml
+++ b/tests/cases/fsi/pipe_RCR_3d/solver.xml
@@ -4,7 +4,7 @@
 <GeneralSimulationParameters>
   <Continue_previous_simulation> 0 </Continue_previous_simulation>
   <Number_of_spatial_dimensions> 3 </Number_of_spatial_dimensions> 
-  <Number_of_time_steps> 50 </Number_of_time_steps> 
+  <Number_of_time_steps> 5 </Number_of_time_steps> 
   <Time_step_size> 1e-4 </Time_step_size> 
   <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
   <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
@@ -12,7 +12,7 @@
   <Name_prefix_of_saved_VTK_files> result </Name_prefix_of_saved_VTK_files> 
   <Increment_in_saving_VTK_files> 5 </Increment_in_saving_VTK_files> 
   <Start_saving_after_time_step> 1 </Start_saving_after_time_step> 
-  <Increment_in_saving_restart_files> 1 </Increment_in_saving_restart_files> 
+  <Increment_in_saving_restart_files> 5 </Increment_in_saving_restart_files> 
   <Convert_BIN_to_VTK_format> 0 </Convert_BIN_to_VTK_format> 
   <Verbose> 1 </Verbose> 
   <Warning> 0 </Warning> 

--- a/tests/cases/fsi/pipe_RCR_3d/solver.xml
+++ b/tests/cases/fsi/pipe_RCR_3d/solver.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svMultiPhysicsFile version="0.1">
+
+<GeneralSimulationParameters>
+  <Continue_previous_simulation> 0 </Continue_previous_simulation>
+  <Number_of_spatial_dimensions> 3 </Number_of_spatial_dimensions> 
+  <Number_of_time_steps> 50 </Number_of_time_steps> 
+  <Time_step_size> 1e-4 </Time_step_size> 
+  <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
+  <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
+  <Save_results_to_VTK_format> true </Save_results_to_VTK_format> 
+  <Name_prefix_of_saved_VTK_files> result </Name_prefix_of_saved_VTK_files> 
+  <Increment_in_saving_VTK_files> 5 </Increment_in_saving_VTK_files> 
+  <Start_saving_after_time_step> 1 </Start_saving_after_time_step> 
+  <Increment_in_saving_restart_files> 1 </Increment_in_saving_restart_files> 
+  <Convert_BIN_to_VTK_format> 0 </Convert_BIN_to_VTK_format> 
+  <Verbose> 1 </Verbose> 
+  <Warning> 0 </Warning> 
+  <Debug> 0 </Debug> 
+</GeneralSimulationParameters>
+
+<Add_mesh name="lumen" > 
+  <Mesh_file_path> mesh/fluid/mesh-complete.mesh.vtu  </Mesh_file_path>
+  <Add_face name="lumen_inlet">
+      <Face_file_path> mesh/fluid/mesh-surfaces/start.vtp </Face_file_path>
+  </Add_face>
+  <Add_face name="lumen_outlet">
+      <Face_file_path> mesh/fluid/mesh-surfaces/end.vtp </Face_file_path>
+  </Add_face>
+  <Add_face name="lumen_wall">
+      <Face_file_path> mesh/fluid/mesh-surfaces/interface.vtp </Face_file_path>
+  </Add_face>
+  <Domain> 0 </Domain>
+
+</Add_mesh>
+
+<Add_mesh name="wall" >
+  <Mesh_file_path> mesh/solid/mesh-complete.mesh.vtu  </Mesh_file_path>
+  <Add_face name="wall_inlet">
+      <Face_file_path> mesh/solid/mesh-surfaces/start.vtp </Face_file_path>
+  </Add_face>
+  <Add_face name="wall_outlet">
+      <Face_file_path> mesh/solid/mesh-surfaces/end.vtp </Face_file_path>
+  </Add_face>
+  <Add_face name="wall_inner">
+      <Face_file_path> mesh/solid/mesh-surfaces/interface.vtp </Face_file_path>
+  </Add_face>
+  <Add_face name="wall_outer">
+      <Face_file_path> mesh/solid/mesh-surfaces/outside.vtp </Face_file_path>
+  </Add_face>
+  <Domain> 1 </Domain>
+</Add_mesh>
+
+<Add_projection name="wall_inner" >
+   <Project_from_face> lumen_wall </Project_from_face>
+</Add_projection> 
+
+<Add_equation type="FSI" > 
+   <Coupled> true </Coupled>
+   <Min_iterations> 1 </Min_iterations>  
+   <Max_iterations> 7 </Max_iterations> 
+   <Tolerance> 1e-12 </Tolerance> 
+
+   <Domain id="0" >
+      <Equation> fluid </Equation> 
+      <Density> 1.0 </Density> 
+      <Viscosity model="Constant" >
+         <Value> 0.04 </Value>
+      </Viscosity>
+      <Backflow_stabilization_coefficient> 0.2 </Backflow_stabilization_coefficient> 
+   </Domain>
+   
+   <Domain id="1" >
+      <Equation> struct </Equation> 
+      <Constitutive_model type="neoHookean"> </Constitutive_model> 
+      <Dilational_penalty_model> M94 </Dilational_penalty_model> 
+      <Density> 1.0 </Density> 
+      <Elasticity_modulus> 1.0e7 </Elasticity_modulus> 
+      <Poisson_ratio> 0.3 </Poisson_ratio> 
+   </Domain>
+
+   <LS type="GMRES" >
+      <Linear_algebra type="fsils" >
+         <Preconditioner> fsils </Preconditioner>
+      </Linear_algebra>
+      <Tolerance> 1e-12 </Tolerance>
+      <Max_iterations> 100 </Max_iterations> 
+      <Krylov_space_dimension> 50 </Krylov_space_dimension>
+   </LS>
+
+   <Output type="Spatial" >
+     <Displacement> true </Displacement>
+     <Velocity> true </Velocity>
+     <Pressure> true </Pressure>
+     <VonMises_stress> true </VonMises_stress>
+   </Output>
+
+   <Output type="Alias" >
+       <Displacement> FS_Displacement </Displacement>
+   </Output>
+
+   <Add_BC name="lumen_inlet" > 
+      <Type> Neu </Type> 
+      <Value> 5.0e4 </Value> 
+   </Add_BC> 
+
+   <Add_BC name="lumen_outlet" > 
+      <Type> Neu </Type> 
+      <Time_dependence> RCR </Time_dependence> 
+      <RCR_values> 
+        <Capacitance> 1.5e-5 </Capacitance> 
+        <Distal_resistance> 1212 </Distal_resistance> 
+        <Proximal_resistance> 121 </Proximal_resistance> 
+        <Distal_pressure> 0 </Distal_pressure> 
+        <Initial_pressure> 0 </Initial_pressure> 
+      </RCR_values> 
+   </Add_BC> 
+
+   <Add_BC name="wall_inlet" > 
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+      <Impose_on_state_variable_integral> true </Impose_on_state_variable_integral> 
+      <Zero_out_perimeter> false </Zero_out_perimeter> 
+      <Effective_direction> (0, 0, 1) </Effective_direction> 
+   </Add_BC> 
+
+   <Add_BC name="wall_outlet" >
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+      <Impose_on_state_variable_integral> true </Impose_on_state_variable_integral>
+      <Zero_out_perimeter> false </Zero_out_perimeter> 
+      <Effective_direction> (0, 0, 1 ) </Effective_direction> 
+   </Add_BC> 
+
+</Add_equation>
+
+
+<Add_equation type="mesh" >
+   <Coupled> true </Coupled>
+   <Min_iterations> 1 </Min_iterations>
+   <Max_iterations> 7 </Max_iterations>
+   <Tolerance> 1e-12 </Tolerance>
+   <Poisson_ratio> 0.3 </Poisson_ratio> 
+
+   <LS type="CG" >
+      <Linear_algebra type="fsils" >
+         <Preconditioner> fsils </Preconditioner>
+      </Linear_algebra>
+      <Tolerance> 1e-12 </Tolerance>
+   </LS>
+
+   <Output type="Spatial" >
+     <Displacement> true </Displacement>
+   </Output>
+
+   <Add_BC name="lumen_inlet" > 
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+   </Add_BC> 
+
+   <Add_BC name="lumen_outlet" > 
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+   </Add_BC> 
+
+</Add_equation>
+
+</svMultiPhysicsFile>

--- a/tests/test_fsi.py
+++ b/tests/test_fsi.py
@@ -26,3 +26,8 @@ def test_pipe_3d_trilinos_ml(n_proc):
     test_folder = "pipe_3d_trilinos_ml"
     t_max = 5
     run_with_reference(base_folder, test_folder, fields, n_proc, t_max)
+
+def test_pipe_RCR_3d(n_proc):
+    test_folder = "pipe_RCR_3d"
+    t_max = 5
+    run_with_reference(base_folder, test_folder, fields, n_proc, t_max)


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Resolves https://github.com/SimVascular/svMultiPhysics/issues/264


## Release Notes 
- Fix bug where `eq.dmn[cDmn].phys` was used instead of `eq.phys` to determine the current physics (e.g. fluid, FSI, struct, etc.) within `set_bc_cpl()`. For an FSI simulation, `eq.dmn[:].phys = [phys_fluid, phys_struct]`. Using `eq.dmn[:].phys` is wrong to begin with because for an FSI simulation, the current physics within `set_bc_cpl()` should be `phys_FSI`. In addition, this causes the bug discussed in https://github.com/SimVascular/svMultiPhysics/issues/264, explained as follows. For some reason, `cDmn` can seemingly randomly switch from 0 to 1, which causes causes `eq.dmn[:].phys` to switch from `phys_fluid` to `phys_struct`, which then yields the `follower pressure load` error discussed in https://github.com/SimVascular/svMultiPhysics/issues/264. Using `eq.phys` fixes these problems because for an FSI simulation, `eq.phys = phys_FSI`.
- Add a case testing FSI + cplBC. This case is the same as the other FSI pipe_3d cases, except uses an RCR boundary condition, which internally calls `set_cpl_bc()`.



## Testing
- Add fsi/pipe_RCR_3d test case to test this combination of FSI and coupled BCs


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
