### PR TITLE
Improve ustruct/LV_Guccione_active convergence

### DIFF
--- a/tests/cases/ustruct/LV_Guccione_active/README.md
+++ b/tests/cases/ustruct/LV_Guccione_active/README.md
@@ -1,0 +1,8 @@
+This test case simulates an idealized left ventricle (LV) with a Guccione material model
+contracting due to time-dependent active stress, and subject to a time-dependent
+pressure load on the endocardial surfaces. The problem set up can be found in
+Problem 3 of (Land et al., 2015)[1]. The simulation result is shown in the animation below.
+
+![Simulation GIF](animation.gif)
+
+[1]: Land, Sander, Viatcheslav Gurev, Sander Arens, Christoph M. Augustin, Lukas Baron, Robert Blake, Chris Bradley, et al. Verification of Cardiac Mechanics Software: Benchmark Problems and Solutions for Testing Active and Passive Material Behaviour. Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences 471, no. 2184 (December 2015): 20150641. https://doi.org/10.1098/rspa.2015.0641.

--- a/tests/cases/ustruct/LV_Guccione_active/animation.avi
+++ b/tests/cases/ustruct/LV_Guccione_active/animation.avi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8a3ab10076ba2c347565319a8034900c1fb6aa7fb3661245e73dbdbc5a82ec9
+size 1681180

--- a/tests/cases/ustruct/LV_Guccione_active/animation.gif
+++ b/tests/cases/ustruct/LV_Guccione_active/animation.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:676500f66bef4d2d0206a869dbc2cd74b559fb9513a49f39b8464f7536210ee6
+size 834055

--- a/tests/cases/ustruct/LV_Guccione_active/result_001.vtu
+++ b/tests/cases/ustruct/LV_Guccione_active/result_001.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe16ff23fdb103812f0f96f7e3c9c4eeb90d783c5994dc0a7017cada9128f23c
-size 72290
+oid sha256:48525854e6062b81e71906a804fe559202dcd692efd3c6debcb7ae4617e1a644
+size 73470

--- a/tests/cases/ustruct/LV_Guccione_active/solver.xml
+++ b/tests/cases/ustruct/LV_Guccione_active/solver.xml
@@ -5,7 +5,7 @@
   <Continue_previous_simulation> 0 </Continue_previous_simulation>
   <Number_of_spatial_dimensions> 3 </Number_of_spatial_dimensions> 
   <Number_of_time_steps> 1 </Number_of_time_steps> 
-  <Time_step_size> 1e-4 </Time_step_size> 
+  <Time_step_size> 1e-3 </Time_step_size> 
   <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
   <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
   <Save_results_to_VTK_format> true </Save_results_to_VTK_format> 
@@ -34,6 +34,8 @@
   <Fiber_direction_file_path> mesh/P1/fibersLong.vtu </Fiber_direction_file_path> 
   <Fiber_direction_file_path> mesh/P1/fibersSheet.vtu </Fiber_direction_file_path> 
 
+  <!-- Mesh is in mm -->
+
 </Add_mesh>
 
 <Add_equation type="ustruct" > 
@@ -43,24 +45,25 @@
    <Tolerance> 1e-12 </Tolerance> 
    <Use_taylor_hood_type_basis> false </Use_taylor_hood_type_basis>
 
-    <Density> 1e-3 </Density> 
+    <Density> 1e-3 </Density> <!-- g/mm^3 -->
     <Elasticity_modulus> 2.0e5 </Elasticity_modulus> 
     <Poisson_ratio> 0.5 </Poisson_ratio> 
    
     <Constitutive_model type="Guccione" > 
-       <c> 2.0e3 </c>  
-       <bf> 8.0 </bf>  
+       <c> 2.0e3 </c>  <!-- g/mm/s^2 or Pa -->
+       <bf> 8.0 </bf>  <!-- no units -->
        <bt> 2.0 </bt> 
        <bfs> 4.0 </bfs>
     </Constitutive_model> 
 
+   <!-- Fiber stress ramp from 0 to 60 kPa in 1s -->
    <Fiber_reinforcement_stress type="Unsteady" > 
       <Temporal_values_file_path> fib_stress.dat </Temporal_values_file_path> 
       <Ramp_function> true </Ramp_function> 
    </Fiber_reinforcement_stress> 
 
-   <Momentum_stabilization_coefficient> 1e-1 </Momentum_stabilization_coefficient> 
-   <Continuity_stabilization_coefficient> 1e-1 </Continuity_stabilization_coefficient> 
+   <Momentum_stabilization_coefficient> 1e-3 </Momentum_stabilization_coefficient> 
+   <Continuity_stabilization_coefficient> 1e-3 </Continuity_stabilization_coefficient> 
 
    <Output type="Spatial" >
      <Pressure> true </Pressure>
@@ -89,6 +92,7 @@
       <Impose_on_state_variable_integral> true </Impose_on_state_variable_integral>
    </Add_BC> 
 
+   <!-- Endocardial pressure load ramp from 0 to 15 kPa in 1s-->
    <Add_BC name="endo" > 
       <Type> Neu </Type> 
       <Time_dependence> Unsteady </Time_dependence>

--- a/tests/unitTests/test.h
+++ b/tests/unitTests/test.h
@@ -30,6 +30,7 @@
 
 // --------------------------------------------------------------
 // To run the tests in test.cpp
+// 0.  Make sure svMultiPhysics was built with unit tests enabled, using cmake -DENABLE_UNIT_TEST=ON ..
 // 1.  Navigate to <svMultiPhysics_root_directory>/build/svMultiPhysics-build/Source/solver
 // 2.  Run `make` to build the tests
 // 3.  Run `ctest --verbose` to run the tests


### PR DESCRIPTION
## Current situation
Resolve https://github.com/SimVascular/svMultiPhysics/issues/197


## Release Notes 
- Reduces momentum and continuity stabilization coefficients to improve nonlinear convergence in ustruct/LV_Guccione_active test case
- Update reference solution `result_001.vtu` accordingly
- Add README.md and animation to describe case and visualize results


## Testing
No testing required. Note however that this modifies the reference solution in ustruct/LV_Guccione_active


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
