### PR TITLE
Remove checked on the first gmres iteration (issue #365)

### DIFF
--- a/Code/Source/liner_solver/gmres.cpp
+++ b/Code/Source/liner_solver/gmres.cpp
@@ -156,13 +156,6 @@ void gmres(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_subLs
 
     if (l == 0) {
       eps = err[0];
-
-      if (eps <= ls.absTol) {
-        ls.callD = std::numeric_limits<double>::epsilon();
-        ls.dB = 0.0;
-        return; 
-      }
-
       ls.iNorm = eps;
       ls.fNorm = eps;
       eps = std::max(ls.absTol, ls.relTol*eps);


### PR DESCRIPTION
The check on the absolute tolerance for the first gmres iteration is removed. At least one linear iteration is allowed to be completed.

## Current situation
When the non-linear residual meet the absolute tolerance criteria of the linear solver, the fsils implementation of the gmres, returns without completing the first linear iteration. This causes a zero-solution which in the BIPN method, triggers a singular matrix error.

## Release Notes 
The check on the first iteration of the gmres is removed and one linear iteration is always allowed, avoiding a zero-solution.

## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
