### PR TITLE
Fix boundary writing issue

### DIFF
--- a/Code/Source/solver/txt.cpp
+++ b/Code/Source/solver/txt.cpp
@@ -497,11 +497,10 @@ void write_boundary_integral_data(const ComMod& com_mod, CmMod& cm_mod, const eq
         fprintf(fp, " %.10e ", tmp);
       }
     }
-
-    if (com_mod.cm.mas(cm_mod)) {
-      fprintf(fp, "\n");
-      fclose(fp);
-    }
+  }
+  if (com_mod.cm.mas(cm_mod)) {
+    fprintf(fp, "\n");
+    fclose(fp);
   }
 }
 


### PR DESCRIPTION
For simulation with multiple meshes, the output txt file should be closed after it loops over all meshes.

<!-- Give your pull request (PR) a descriptive name -->

## Current situation
The boundary‐integral output file was being closed inside the per‑mesh loop, triggering a “double free or corruption” error and crashing the solver on the first iteration. 


## Release Notes 
The file is now closed only after iterating over all meshes.


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
