### PR TITLE
Updating CMake file

### DIFF
--- a/Code/CMake/SimVascularSystemSetup.cmake
+++ b/Code/CMake/SimVascularSystemSetup.cmake
@@ -157,6 +157,13 @@ if(APPLE)
   # Assuming use mac os if APPLE
   set(SV_PLATFORM_DIR "mac_osx" CACHE STRING "The distribution platform being used.")
 
+  # Safely fetch CURRENT_OSX_VERSION if undefined
+  if(NOT DEFINED CURRENT_OSX_VERSION OR CURRENT_OSX_VERSION STREQUAL "")
+    execute_process(COMMAND sw_vers -productVersion
+                    OUTPUT_VARIABLE CURRENT_OSX_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+  
   # Get just major minor version of osx
   simvascular_get_major_minor_version(${CURRENT_OSX_VERSION} SV_OSX_MAJOR_VERSION SV_OSX_MINOR_VERSION)
 


### PR DESCRIPTION
Updating CMake file to fetch the correct version of MacOS

## Current situation
The new macOS runner image on GitHub Actions no longer provides the current macOS version in a way that current CMake file expect. As a result, builds on macos-latest fail at the configuration stage due to the simvascular_get_major_minor_version macro receiving an empty value.

## Release Notes 
SimVascularSystemSetup.cmake file has been updated to explicitly query the current macOS version using the system command sw_vers -productVersion. This ensures that the major and minor macOS version numbers are correctly detected during configuration, allowing builds on GitHub Actions macOS runners to succeed.

## Documentation
No documentation needed.

## Testing
No need for test.

## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
