### PR TITLE
Remove redundant brew install cmake in MacOS workflow file

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install MacOS dependencies
         run: |
           brew reinstall -v gcc
-          brew install -v cmake vtk openblas lapack mesa open-mpi qt
+          brew install -v vtk openblas lapack mesa open-mpi qt
           brew install lcov
           sudo ln -s /usr/local/opt/qt5/mkspecs /usr/local/mkspecs
           sudo ln -s /usr/local/opt/qt5/plugins /usr/local/plugins


### PR DESCRIPTION
Removed redundant installation of cmake from MacOS dependencies.

<!-- Give your pull request (PR) a descriptive name -->

## Current situation
MacOS tests were failing because of 

```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.

To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake
```


## Release Notes 
- Remove `cmake` from list of packages installed by `brew`


## Testing
- No testing, will see if macos tests pass with this change.


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
