### PR TITLE
Spatially variable Robin BC bug fixes

### DIFF
--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -443,7 +443,6 @@ BoundaryConditionParameters::BoundaryConditionParameters()
   set_parameter("Spatial_profile_file_path", "", !required, spatial_profile_file_path);
   set_parameter("Spatial_values_file_path", "", !required, spatial_values_file_path);
   set_parameter("Stiffness", 1.0, !required, stiffness);
-  set_parameter("Robin_vtp_file_path", "", !required, robin_vtp_file_path);
   set_parameter("svZeroDSolver_block", "", !required, svzerod_solver_block);
 
   set_parameter("Temporal_and_spatial_values_file_path", "", !required, temporal_and_spatial_values_file_path);

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -806,7 +806,6 @@ class BoundaryConditionParameters : public ParameterLists
     Parameter<std::string> spatial_profile_file_path;
     Parameter<std::string> spatial_values_file_path;
     Parameter<double> stiffness;
-    Parameter<std::string> robin_vtp_file_path;
     Parameter<std::string> svzerod_solver_block;
 
     Parameter<std::string> temporal_and_spatial_values_file_path;

--- a/Code/Source/solver/RobinBoundaryCondition.cpp
+++ b/Code/Source/solver/RobinBoundaryCondition.cpp
@@ -29,6 +29,17 @@
  */
 
 #include "RobinBoundaryCondition.h"
+#include <iostream>
 
 #define n_debug_robin_bc
+
+RobinBoundaryCondition::RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face)
+    : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face)
+{
+    // Warning if both stiffness and damping are zero
+    if (uniform_stiffness == 0.0 && uniform_damping == 0.0) {
+        std::cout << "WARNING: Robin boundary condition has both stiffness and damping values set to zero. "
+                  << "This will result in effectively no boundary condition being applied." << std::endl;
+    }
+}
 

--- a/Code/Source/solver/RobinBoundaryCondition.h
+++ b/Code/Source/solver/RobinBoundaryCondition.h
@@ -83,8 +83,7 @@ public:
     /// @param normal_only Flag to apply only along normal direction
     /// @param face Face associated with the Robin BC
     /// @throws BoundaryConditionValidationException if values are invalid
-    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face)
-        : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face) {}
+    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face);
  
     /// @brief Apply only along normal direction (getter)
     /// @return true if BC should be applied only along normal direction

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -394,8 +394,8 @@ void read_bc(Simulation* simulation, EquationParameters* eq_params, eqType& lEq,
   if (utils::btest(lBc.bType, enum_int(BoundaryConditionType::bType_Robin))) { 
     
     // Read VTP file path for per-node stiffness and damping (optional)
-    if (bc_params->robin_vtp_file_path.defined()) {
-      lBc.robin_bc = RobinBoundaryCondition(bc_params->robin_vtp_file_path.value(), 
+    if (bc_params->spatial_values_file_path.defined()) {
+      lBc.robin_bc = RobinBoundaryCondition(bc_params->spatial_values_file_path.value(), 
                                             bc_params->apply_along_normal_direction.value(),
                                             com_mod.msh[lBc.iM].fa[lBc.iFa]);
     } else {

--- a/tests/cases/struct/spatially_variable_robin/solver.xml
+++ b/tests/cases/struct/spatially_variable_robin/solver.xml
@@ -132,7 +132,7 @@
 
    <Add_BC name="Y0" > 
       <Type> Robin </Type> 
-      <Robin_vtp_file_path> Y0_spatially_varying_robin.vtp </Robin_vtp_file_path> 
+      <Spatial_values_file_path> Y0_spatially_varying_robin.vtp </Spatial_values_file_path> 
       <Apply_along_normal_direction> false </Apply_along_normal_direction> 
    </Add_BC> 
 

--- a/tests/cases/ustruct/spatially_variable_robin/solver.xml
+++ b/tests/cases/ustruct/spatially_variable_robin/solver.xml
@@ -134,7 +134,7 @@
 
    <Add_BC name="Y0" > 
       <Type> Robin </Type> 
-      <Robin_vtp_file_path> Y0_spatially_varying_robin.vtp </Robin_vtp_file_path> 
+      <Spatial_values_file_path> Y0_spatially_varying_robin.vtp </Spatial_values_file_path> 
    </Add_BC> 
 
    <Add_BC name="Y1" > 


### PR DESCRIPTION


## Current situation
Resolves https://github.com/SimVascular/svMultiPhysics/issues/444


## Release Notes 
- Replace `<Robin_vtp_file_path>` xml element with `<Spatial_values_file_path>` for providing path to spatially variable Robin boundary condition .vtp file.
- Also, add warning to uniform values `RobinBoundaryCondition` constructor if both `stiffness` and `damping` are 0.
- Fix point matching bug when `mesh_scale_factor` is not 1.


## Testing
Modifies `struct/spatially_variable_robin` and `ustruct/spatially_variable_robin` tests with new xml format.


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
