### PR TITLE
Spatially variable robin bug fixes

### DIFF
--- a/Code/Source/solver/BoundaryCondition.h
+++ b/Code/Source/solver/BoundaryCondition.h
@@ -36,6 +36,7 @@
 #include "CmMod.h"
 #include "VtkData.h"
 #include <string>
+#include "SimulationLogger.h"
 #include <memory>
 #include <map>
 #include <vector>
@@ -90,6 +91,7 @@ protected:
     std::string vtp_file_path_;              ///< Path to VTP file (empty if uniform)
     std::map<int, int> global_node_map_;     ///< Maps global node IDs to local array indices
     std::unique_ptr<VtkVtpData> vtp_data_;   ///< VTP data object
+    SimulationLogger* logger_ = nullptr;     ///< Logger for warnings/info
 
 public:
     /// @brief Tolerance for point matching in VTP files
@@ -102,13 +104,15 @@ public:
     /// @param vtp_file_path Path to VTP file containing arrays
     /// @param array_names Names of arrays to read from VTP file
     /// @param face Face associated with the BC
+    /// @param logger Simulation logger used to write warnings
     /// @throws std::runtime_error if file cannot be read or arrays are missing
-    BoundaryCondition(const std::string& vtp_file_path, const std::vector<std::string>& array_names, const StringBoolMap& flags, const faceType& face);
+    BoundaryCondition(const std::string& vtp_file_path, const std::vector<std::string>& array_names, const StringBoolMap& flags, const faceType& face, SimulationLogger& logger);
 
     /// @brief Constructor for uniform values
     /// @param uniform_values Map of array names to uniform values
     /// @param face Face associated with the BC
-    BoundaryCondition(const StringDoubleMap& uniform_values, const StringBoolMap& flags, const faceType& face);
+    /// @param logger Simulation logger used to write warnings
+    BoundaryCondition(const StringDoubleMap& uniform_values, const StringBoolMap& flags, const faceType& face, SimulationLogger& logger);
 
     /// @brief Copy constructor
     BoundaryCondition(const BoundaryCondition& other);

--- a/Code/Source/solver/BoundaryCondition.h
+++ b/Code/Source/solver/BoundaryCondition.h
@@ -198,9 +198,10 @@ protected:
     /// @param y Y coordinate
     /// @param z Z coordinate
     /// @param vtp_points VTP points array
+    /// @param mesh_scale_factor Scale factor applied to mesh coordinates
     /// @return Index of the matching point in the VTP array
     /// @throws std::runtime_error if no matching point is found
-    int find_vtp_point_index(double x, double y, double z, const Array<double>& vtp_points) const;
+    int find_vtp_point_index(double x, double y, double z, const Array<double>& vtp_points, double mesh_scale_factor) const;
 
     /// @brief Hook for derived classes to validate array values
     /// @param array_name Name of the array being validated

--- a/Code/Source/solver/BoundaryCondition.h
+++ b/Code/Source/solver/BoundaryCondition.h
@@ -80,7 +80,7 @@ protected:
     using StringDoubleMap = std::map<std::string, double>;
 
     /// @brief Data members for BC
-    const faceType* face_ = nullptr;         ///< Face associated with the BC (can be null)
+    const faceType* face_ = nullptr;         ///< Face associated with the BC (not owned by BoundaryCondition)
     int global_num_nodes_ = 0;               ///< Global number of nodes on the face
     int local_num_nodes_ = 0;                ///< Local number of nodes on this processor
     std::vector<std::string> array_names_;   ///< Names of arrays to read from VTP file
@@ -91,7 +91,7 @@ protected:
     std::string vtp_file_path_;              ///< Path to VTP file (empty if uniform)
     std::map<int, int> global_node_map_;     ///< Maps global node IDs to local array indices
     std::unique_ptr<VtkVtpData> vtp_data_;   ///< VTP data object
-    SimulationLogger* logger_ = nullptr;     ///< Logger for warnings/info
+    const SimulationLogger* logger_ = nullptr;  ///< Logger for warnings/info (not owned by BoundaryCondition)
 
 public:
     /// @brief Tolerance for point matching in VTP files

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -443,7 +443,6 @@ BoundaryConditionParameters::BoundaryConditionParameters()
   set_parameter("Spatial_profile_file_path", "", !required, spatial_profile_file_path);
   set_parameter("Spatial_values_file_path", "", !required, spatial_values_file_path);
   set_parameter("Stiffness", 1.0, !required, stiffness);
-  set_parameter("Robin_vtp_file_path", "", !required, robin_vtp_file_path);
   set_parameter("svZeroDSolver_block", "", !required, svzerod_solver_block);
 
   set_parameter("Temporal_and_spatial_values_file_path", "", !required, temporal_and_spatial_values_file_path);

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -806,7 +806,6 @@ class BoundaryConditionParameters : public ParameterLists
     Parameter<std::string> spatial_profile_file_path;
     Parameter<std::string> spatial_values_file_path;
     Parameter<double> stiffness;
-    Parameter<std::string> robin_vtp_file_path;
     Parameter<std::string> svzerod_solver_block;
 
     Parameter<std::string> temporal_and_spatial_values_file_path;

--- a/Code/Source/solver/RobinBoundaryCondition.cpp
+++ b/Code/Source/solver/RobinBoundaryCondition.cpp
@@ -33,13 +33,13 @@
 
 #define n_debug_robin_bc
 
-RobinBoundaryCondition::RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face)
-    : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face)
+RobinBoundaryCondition::RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face, SimulationLogger& logger)
+    : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face, logger)
 {
     // Warning if both stiffness and damping are zero
     if (uniform_stiffness == 0.0 && uniform_damping == 0.0) {
-        std::cout << "WARNING: Robin boundary condition has both stiffness and damping values set to zero. "
-                  << "This will result in effectively no boundary condition being applied." << std::endl;
+        logger_ -> log_message("WARNING [RobinBoundaryCondition] Both stiffness and damping values set to zero. "
+                   "This will result in effectively no boundary condition being applied.");
     }
 }
 

--- a/Code/Source/solver/RobinBoundaryCondition.cpp
+++ b/Code/Source/solver/RobinBoundaryCondition.cpp
@@ -29,6 +29,17 @@
  */
 
 #include "RobinBoundaryCondition.h"
+#include <iostream>
 
 #define n_debug_robin_bc
+
+RobinBoundaryCondition::RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face)
+    : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face)
+{
+    // Warning if both stiffness and damping are zero
+    if (uniform_stiffness == 0.0 && uniform_damping == 0.0) {
+        std::cout << "WARNING: Robin boundary condition has both stiffness and damping values set to zero. "
+                  << "This will result in effectively no boundary condition being applied." << std::endl;
+    }
+}
 

--- a/Code/Source/solver/RobinBoundaryCondition.h
+++ b/Code/Source/solver/RobinBoundaryCondition.h
@@ -83,8 +83,7 @@ public:
     /// @param normal_only Flag to apply only along normal direction
     /// @param face Face associated with the Robin BC
     /// @throws BoundaryConditionValidationException if values are invalid
-    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face)
-        : BoundaryCondition({{"Stiffness", uniform_stiffness}, {"Damping", uniform_damping}}, StringBoolMap{{"normal_direction_only", normal_only}}, face) {}
+    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face);
  
     /// @brief Apply only along normal direction (getter)
     /// @return true if BC should be applied only along normal direction

--- a/Code/Source/solver/RobinBoundaryCondition.h
+++ b/Code/Source/solver/RobinBoundaryCondition.h
@@ -70,11 +70,12 @@ public:
     /// @param vtp_file_path Path to VTP file containing Stiffness and Damping point arrays
     /// @param normal_only Flag to apply only along normal direction
     /// @param face Face associated with the Robin BC
+    /// @param logger Simulation logger used to write warnings
     /// @throws BoundaryConditionFileException if file cannot be read
     /// @throws BoundaryConditionVtpArrayException if arrays are missing
     /// @throws BoundaryConditionValidationException if values are invalid
-    RobinBoundaryCondition(const std::string& vtp_file_path, bool normal_only, const faceType& face)
-        : BoundaryCondition(vtp_file_path, std::vector<std::string>{"Stiffness", "Damping"}, StringBoolMap{{"normal_direction_only", normal_only}}, face) {}
+    RobinBoundaryCondition(const std::string& vtp_file_path, bool normal_only, const faceType& face, SimulationLogger& logger)
+        : BoundaryCondition(vtp_file_path, std::vector<std::string>{"Stiffness", "Damping"}, StringBoolMap{{"normal_direction_only", normal_only}}, face, logger) {}
 
 
     /// @brief Constructor for uniform values
@@ -82,8 +83,9 @@ public:
     /// @param uniform_damping Uniform damping value for all nodes
     /// @param normal_only Flag to apply only along normal direction
     /// @param face Face associated with the Robin BC
+    /// @param logger Simulation logger used to write warnings
     /// @throws BoundaryConditionValidationException if values are invalid
-    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face);
+    RobinBoundaryCondition(double uniform_stiffness, double uniform_damping, bool normal_only, const faceType& face, SimulationLogger& logger);
  
     /// @brief Apply only along normal direction (getter)
     /// @return true if BC should be applied only along normal direction

--- a/Code/Source/solver/SimulationLogger.h
+++ b/Code/Source/solver/SimulationLogger.h
@@ -58,6 +58,8 @@ class SimulationLogger {
       file_name_ = file_name;
     }
 
+    bool is_initialized() const { return log_file_.is_open(); }
+
     ~SimulationLogger() 
     {
       log_file_.close();
@@ -78,6 +80,27 @@ class SimulationLogger {
     return *this;
   }
 
+  // Special handling for vector<string>
+  SimulationLogger& operator<< (const std::vector<std::string>& values)
+  {
+    if (file_name_ == "") { 
+      return *this;
+    }
+
+    bool first = true;
+    for (const auto& value : values) {
+      if (!first) {
+        log_file_ << ", ";
+        if (cout_write_) std::cout << ", ";
+      }
+      log_file_ << value;
+      if (cout_write_) std::cout << value;
+      first = false;
+    }
+
+    return *this;
+  }
+
   SimulationLogger& operator<<(std::ostream&(*value)(std::ostream& o))
   {
     if (file_name_ == "") { 
@@ -93,8 +116,21 @@ class SimulationLogger {
     return *this;
   };
 
+  /// @brief Log a message with automatic space separation
+  /// @param args Arguments to log
+  template<typename... Args>
+  SimulationLogger& log_message(const Args&... args) {
+    if (file_name_ == "") return *this;
+
+    bool first = true;
+    ((first ? (first = false, (*this << args)) : (*this << ' ' << args)), ...);
+    *this << std::endl;
+    return *this;
+  }
+
   private:
     bool cout_write_ = false;
+    bool initialized_ = false;
     std::string file_name_;
     std::ofstream log_file_;
 };

--- a/Code/Source/solver/SimulationLogger.h
+++ b/Code/Source/solver/SimulationLogger.h
@@ -47,7 +47,7 @@ class SimulationLogger {
       this->initialize(file_name, cout_write);
     }
 
-    void initialize(const std::string& file_name, bool cout_write=false) 
+    void initialize(const std::string& file_name, bool cout_write=false) const
     {
       log_file_.open(file_name);
       if (log_file_.fail()) {
@@ -65,7 +65,7 @@ class SimulationLogger {
       log_file_.close();
     }
 
-  template <class T> SimulationLogger& operator<< (const T& value)
+  template <class T> const SimulationLogger& operator<< (const T& value) const
   {
     if (file_name_ == "") { 
       return *this;
@@ -81,7 +81,7 @@ class SimulationLogger {
   }
 
   // Special handling for vector<string>
-  SimulationLogger& operator<< (const std::vector<std::string>& values)
+  const SimulationLogger& operator<< (const std::vector<std::string>& values) const
   {
     if (file_name_ == "") { 
       return *this;
@@ -101,7 +101,7 @@ class SimulationLogger {
     return *this;
   }
 
-  SimulationLogger& operator<<(std::ostream&(*value)(std::ostream& o))
+  const SimulationLogger& operator<<(std::ostream&(*value)(std::ostream& o)) const
   {
     if (file_name_ == "") { 
       return *this;
@@ -119,7 +119,7 @@ class SimulationLogger {
   /// @brief Log a message with automatic space separation
   /// @param args Arguments to log
   template<typename... Args>
-  SimulationLogger& log_message(const Args&... args) {
+  const SimulationLogger& log_message(const Args&... args) const {
     if (file_name_ == "") return *this;
 
     bool first = true;
@@ -129,10 +129,14 @@ class SimulationLogger {
   }
 
   private:
-    bool cout_write_ = false;
-    bool initialized_ = false;
-    std::string file_name_;
-    std::ofstream log_file_;
+    // These members are marked mutable because they can be modified in const member functions.
+    // While logging writes to a file (modifying these members), it doesn't change the logical
+    // state of the logger - this is exactly what mutable is designed for: implementation
+    // details that need to change even when the object's public state remains constant.
+    mutable bool cout_write_ = false;
+    mutable bool initialized_ = false;
+    mutable std::string file_name_;
+    mutable std::ofstream log_file_;
 };
 
 #endif

--- a/Code/Source/solver/initialize.cpp
+++ b/Code/Source/solver/initialize.cpp
@@ -371,22 +371,6 @@ void initialize(Simulation* simulation, Vector<double>& timeP)
   dmsg.banner();
   #endif
 
-  // Setup logging to history file.
-  if (!simulation->com_mod.cm.slv(simulation->cm_mod)) {
-    std::string hist_file_name;
-
-    if (chnl_mod.appPath != "") { 
-      auto mkdir_arg = std::string("mkdir -p ") + chnl_mod.appPath;
-      std::system(mkdir_arg.c_str());
-      hist_file_name = chnl_mod.appPath + "/" + simulation->history_file_name;
-    } else {
-      hist_file_name = simulation->history_file_name;
-    }
-
-    bool output_to_cout = true;
-    simulation->logger.initialize(hist_file_name, output_to_cout);
-  }
-
   #ifdef debug_initialize
   dmsg << "Set time " << std::endl;
   dmsg << "com_mod.timeP[0]: " << com_mod.timeP[0] << std::endl;

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -394,8 +394,8 @@ void read_bc(Simulation* simulation, EquationParameters* eq_params, eqType& lEq,
   if (utils::btest(lBc.bType, enum_int(BoundaryConditionType::bType_Robin))) { 
     
     // Read VTP file path for per-node stiffness and damping (optional)
-    if (bc_params->robin_vtp_file_path.defined()) {
-      lBc.robin_bc = RobinBoundaryCondition(bc_params->robin_vtp_file_path.value(), 
+    if (bc_params->spatial_values_file_path.defined()) {
+      lBc.robin_bc = RobinBoundaryCondition(bc_params->spatial_values_file_path.value(), 
                                             bc_params->apply_along_normal_direction.value(),
                                             com_mod.msh[lBc.iM].fa[lBc.iFa]);
     } else {

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -397,12 +397,14 @@ void read_bc(Simulation* simulation, EquationParameters* eq_params, eqType& lEq,
     if (bc_params->spatial_values_file_path.defined()) {
       lBc.robin_bc = RobinBoundaryCondition(bc_params->spatial_values_file_path.value(), 
                                             bc_params->apply_along_normal_direction.value(),
-                                            com_mod.msh[lBc.iM].fa[lBc.iFa]);
+                                            com_mod.msh[lBc.iM].fa[lBc.iFa],
+                                            simulation->logger);
     } else {
       lBc.robin_bc = RobinBoundaryCondition(bc_params->stiffness.value(), 
                                             bc_params->damping.value(),
                                             bc_params->apply_along_normal_direction.value(),
-                                            com_mod.msh[lBc.iM].fa[lBc.iFa]);
+                                            com_mod.msh[lBc.iM].fa[lBc.iFa],
+                                            simulation->logger);
     }
   }
 
@@ -1703,7 +1705,23 @@ void read_files(Simulation* simulation, const std::string& file_name)
     com_mod.stFileFlag = gen_params.continue_previous_simulation.value();
   }
 
-  // Set simulatioin and module member data from XML parameters.
+  // Setup logging to history file.
+  if (!simulation->com_mod.cm.slv(simulation->cm_mod)) {
+    std::string hist_file_name;
+
+    if (chnl_mod.appPath != "") { 
+      auto mkdir_arg = std::string("mkdir -p ") + chnl_mod.appPath;
+      std::system(mkdir_arg.c_str());
+      hist_file_name = chnl_mod.appPath + "/" + simulation->history_file_name;
+    } else {
+      hist_file_name = simulation->history_file_name;
+    }
+
+    bool output_to_cout = true;
+    simulation->logger.initialize(hist_file_name, output_to_cout);
+  }
+
+  // Set simulation and module member data from XML parameters.
   simulation->set_module_parameters();
 
   // Read mesh and BCs data.

--- a/tests/cases/struct/spatially_variable_robin/solver.xml
+++ b/tests/cases/struct/spatially_variable_robin/solver.xml
@@ -132,7 +132,7 @@
 
    <Add_BC name="Y0" > 
       <Type> Robin </Type> 
-      <Robin_vtp_file_path> Y0_spatially_varying_robin.vtp </Robin_vtp_file_path> 
+      <Spatial_values_file_path> Y0_spatially_varying_robin.vtp </Spatial_values_file_path> 
       <Apply_along_normal_direction> false </Apply_along_normal_direction> 
    </Add_BC> 
 

--- a/tests/cases/ustruct/spatially_variable_robin/solver.xml
+++ b/tests/cases/ustruct/spatially_variable_robin/solver.xml
@@ -134,7 +134,7 @@
 
    <Add_BC name="Y0" > 
       <Type> Robin </Type> 
-      <Robin_vtp_file_path> Y0_spatially_varying_robin.vtp </Robin_vtp_file_path> 
+      <Spatial_values_file_path> Y0_spatially_varying_robin.vtp </Spatial_values_file_path> 
    </Add_BC> 
 
    <Add_BC name="Y1" > 


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Resolves https://github.com/SimVascular/svMultiPhysics/issues/444


## Release Notes 
- Replace `<Robin_vtp_file_path>` xml element with `<Spatial_values_file_path>` for providing path to spatially variable Robin boundary condition .vtp file.
- Also, add warning to uniform values `RobinBoundaryCondition` constructor if both stiffness and damping are 0.
- Fix point matching bug when `mesh_scale_factor` is not 1.


## Testing
Modifies struct/spatially_variable_robin and ustruct/spatially_variable_robin tests with new xml format.


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
