### PR TITLE
Fix issues with history output

### DIFF
--- a/Code/Source/solver/Integrator.cpp
+++ b/Code/Source/solver/Integrator.cpp
@@ -158,8 +158,9 @@ bool Integrator::step(bool save_results) {
     // Writing out the time passed, residual, and etc. The converged iteration
     // is flagged with an 's' when the results of this time step are saved to a
     // file.
-    const int co = (all_converged && save_results) ? 3 : 2;
-    output::output_result(simulation_, com_mod.timeP, co, iEqOld);
+    output::output_result(simulation_, com_mod.timeP,
+                          /* save_results = */ all_converged && save_results,
+                          iEqOld);
 
     // Check if all equations converged
     if (all_converged) {

--- a/Code/Source/solver/Integrator.cpp
+++ b/Code/Source/solver/Integrator.cpp
@@ -58,10 +58,6 @@ void Integrator::initialize_arrays() {
   solutions_.current.get_velocity() = solutions_.old.get_velocity();
 }
 
-//------------------------
-// step
-//------------------------
-/// @brief Execute one Newton iteration loop for the current time step
 bool Integrator::step(bool save_results) {
   using namespace consts;
 
@@ -159,8 +155,9 @@ bool Integrator::step(bool save_results) {
     // Solution is obtained, now updating (Corrector) and check for convergence
     bool all_converged = corrector_and_check_convergence();
 
-    // Writing out the time passed, residual, and etc. The converged iteration is
-    // flagged with an 's' when the results of this time step are saved to a file.
+    // Writing out the time passed, residual, and etc. The converged iteration
+    // is flagged with an 's' when the results of this time step are saved to a
+    // file.
     const int co = (all_converged && save_results) ? 3 : 2;
     output::output_result(simulation_, com_mod.timeP, co, iEqOld);
 

--- a/Code/Source/solver/Integrator.cpp
+++ b/Code/Source/solver/Integrator.cpp
@@ -62,7 +62,7 @@ void Integrator::initialize_arrays() {
 // step
 //------------------------
 /// @brief Execute one Newton iteration loop for the current time step
-bool Integrator::step() {
+bool Integrator::step(bool save_results) {
   using namespace consts;
 
   auto& com_mod = simulation_->com_mod;
@@ -159,6 +159,11 @@ bool Integrator::step() {
     // Solution is obtained, now updating (Corrector) and check for convergence
     bool all_converged = corrector_and_check_convergence();
 
+    // Writing out the time passed, residual, and etc. The converged iteration is
+    // flagged with an 's' when the results of this time step are saved to a file.
+    const int co = (all_converged && save_results) ? 3 : 2;
+    output::output_result(simulation_, com_mod.timeP, co, iEqOld);
+
     // Check if all equations converged
     if (all_converged) {
       #ifdef debug_integrator_step
@@ -168,7 +173,6 @@ bool Integrator::step() {
       return true;
     }
 
-    output::output_result(simulation_, com_mod.timeP, 2, iEqOld);
     newton_count_ += 1;
   } // End of Newton iteration loop
 }

--- a/Code/Source/solver/Integrator.h
+++ b/Code/Source/solver/Integrator.h
@@ -37,10 +37,16 @@ public:
    *
    * Performs the complete Newton iteration sequence including initialization,
    * assembly, boundary condition application, linear solve, and convergence check.
+   * One line is written to the standard output and to the history file for every
+   * Newton iteration, including the converged one.
+   *
+   * @param[in] save_results True if the results of this time step are written to a
+   *   VTU file, which flags the converged iteration with an 's' in the standard
+   *   output.
    *
    * @return True if all equations converged, false otherwise
    */
-  bool step();
+  bool step(bool save_results = false);
 
   /**
    * @brief Perform predictor step for next time step

--- a/Code/Source/solver/initialize.cpp
+++ b/Code/Source/solver/initialize.cpp
@@ -894,10 +894,8 @@ void initialize(Simulation* simulation, Vector<double>& timeP)
   init_txt_solutions.old.get_displacement() = Do;
   txt_ns::txt(simulation, true, init_txt_solutions);
 
-  // Printing the first line and initializing timeP
-  int co = 1;
-  int iEq = 0;
-  output::output_result(simulation, com_mod.timeP, co, iEq);
+  // Printing the header of the history table and initializing timeP
+  output::output_header(simulation, com_mod.timeP);
 
   std::fill(com_mod.rmsh.flag.begin(), com_mod.rmsh.flag.end(), false);
   com_mod.resetSim = false;

--- a/Code/Source/solver/main.cpp
+++ b/Code/Source/solver/main.cpp
@@ -253,7 +253,6 @@ void iterate_solution(Simulation* simulation)
 
   bool l1 = false;
   bool l2 = false;
-  bool l3 = false;
 
   #ifdef debug_iterate_solution
   dmsg << "Start Outer Loop ..." << std::endl;
@@ -349,8 +348,11 @@ void iterate_solution(Simulation* simulation)
     dmsg << "Starting Newton iteration via Integrator ..." << std::endl;
     #endif
 
-    int iEqOld = cEq;
-    integrator.step();
+    // Results of this time step are written to a VTU file
+    const bool save_vtu = com_mod.saveVTK && cTS % com_mod.saveIncr == 0 &&
+                          cTS >= com_mod.saveATS;
+
+    integrator.step(save_vtu);
 
     #ifdef debug_iterate_solution
     dmsg << ">>> End of Newton iteration" << std::endl;
@@ -471,28 +473,13 @@ void iterate_solution(Simulation* simulation)
     // Writing results into the disk with VTU format
     //
     #ifdef debug_iterate_solution
-    dmsg; 
-    dmsg << "saveVTK: " << com_mod.saveVTK; 
+    dmsg;
+    dmsg << "saveVTK: " << com_mod.saveVTK;
+    dmsg << "save_vtu: " << save_vtu;
     #endif
 
-    if (com_mod.saveVTK) {
-      l2 = ((cTS % com_mod.saveIncr) == 0);
-      l3 = (cTS >= com_mod.saveATS);
-      #ifdef debug_iterate_solution
-      dmsg << "l2: " << l2; 
-      dmsg << "l3: " << l3; 
-      #endif
-
-      if (l2 && l3) {
-        output::output_result(simulation, com_mod.timeP, 3, iEqOld);
-        bool lAvg = false;
-        vtk_xml::write_vtus(simulation, solutions, lAvg);
-      } else {
-        output::output_result(simulation, com_mod.timeP, 2, iEqOld);
-      }
-
-    } else {
-      output::output_result(simulation, com_mod.timeP, 2, iEqOld);
+    if (save_vtu) {
+      vtk_xml::write_vtus(simulation, solutions, /* lAvg = */ false);
     }
 
     // [NOTE] Not implemented.
@@ -536,7 +523,7 @@ void iterate_solution(Simulation* simulation)
       }
 
       if (cm.mas(cm_mod)) {
-        if (l2 && l3) {
+        if (save_vtu) {
           uris::uris_write_vtus(com_mod);
         }
       }

--- a/Code/Source/solver/main.cpp
+++ b/Code/Source/solver/main.cpp
@@ -251,9 +251,6 @@ void iterate_solution(Simulation* simulation)
   auto& Yn = solutions.current.get_velocity();     // New variables (velocity)
   auto& Dn = solutions.current.get_displacement(); // New integrated variables (displacement)
 
-  bool l1 = false;
-  bool l2 = false;
-
   #ifdef debug_iterate_solution
   dmsg << "Start Outer Loop ..." << std::endl;
   #endif
@@ -405,39 +402,33 @@ void iterate_solution(Simulation* simulation)
 
     txt_ns::txt(simulation, false, solutions);
 
-    // If remeshing is required then save current solution.
-    //
-    if (com_mod.rmsh.isReqd) {
-      l1 = ((cTS % com_mod.rmsh.cpVar) == 0);
-      if (l1) {
-        #ifdef debug_iterate_solution
-        dmsg << "Saving last solution for remeshing." << std::endl; 
-        #endif
-        com_mod.rmsh.rTS = cTS - 1;
-        com_mod.rmsh.time = time - dt;
-        for (int i = 0; i < com_mod.rmsh.iNorm.size(); i++) {
-          com_mod.rmsh.iNorm(i) = com_mod.eq[i].iNorm;
-        }
-
-        com_mod.rmsh.A0 = Ao;
-        com_mod.rmsh.Y0 = Yo;
-        com_mod.rmsh.D0 = Do;
+    if (com_mod.rmsh.isReqd &&           // remeshing is required...
+        cTS % com_mod.rmsh.cpVar == 0) { // ...and this is a time step when the
+                                         // solution is saved for remeshing
+      #ifdef debug_iterate_solution
+      dmsg << "Saving last solution for remeshing." << std::endl;
+      #endif
+      com_mod.rmsh.rTS = cTS - 1;
+      com_mod.rmsh.time = time - dt;
+      for (int i = 0; i < com_mod.rmsh.iNorm.size(); i++) {
+        com_mod.rmsh.iNorm(i) = com_mod.eq[i].iNorm;
       }
+
+      com_mod.rmsh.A0 = Ao;
+      com_mod.rmsh.Y0 = Yo;
+      com_mod.rmsh.D0 = Do;
     }
 
     // Look for a file containg a time step to stop the simulation.
     //
     // stopTrigName = "STOP_SIM"
     //
-    auto& stopTrigName = com_mod.stopTrigName;
-    bool l1 = false;
+    auto &stopTrigName = com_mod.stopTrigName;
     int stopTS = 0;
-    int count = -1;
 
     if (cm.mas(cm_mod)) {
       if (FILE *fp = fopen(stopTrigName.c_str(), "r")) {
-        l1 = true;
-        count = fscanf(fp, "%d", &stopTS);
+        const int count = fscanf(fp, "%d", &stopTS);
 
         if (count == 0) {
           stopTS = cTS;
@@ -455,19 +446,19 @@ void iterate_solution(Simulation* simulation)
 
     cm.bcast(cm_mod, &stopTS);
 
-    l1 = (cTS >= stopTS);
-    l2 = ((cTS % com_mod.stFileIncr) == 0);
+    const bool reached_stop_time_step = cTS >= stopTS;
+    const bool is_restart_output_step = cTS % com_mod.stFileIncr == 0;
 
     #ifdef debug_iterate_solution
-    dmsg; 
-    dmsg << "stFileIncr: " << com_mod.stFileIncr; 
-    dmsg << "l1: " << l1; 
-    dmsg << "l2: " << l2; 
+    dmsg;
+    dmsg << "stFileIncr: " << com_mod.stFileIncr;
+    dmsg << "reached_stop_time_step: " << reached_stop_time_step;
+    dmsg << "is_restart_output_step: " << is_restart_output_step;
     #endif
 
     // Saving the result to restart bin file
-    if (l1 || l2) {
-       output::write_restart(simulation, com_mod.timeP, solutions);
+    if (reached_stop_time_step || is_restart_output_step) {
+      output::write_restart(simulation, com_mod.timeP, solutions);
     }
 
     // Writing results into the disk with VTU format
@@ -528,10 +519,9 @@ void iterate_solution(Simulation* simulation)
         }
       }
     }
-    // end RIS/URIS stuff 
+    // end RIS/URIS stuff
 
-    // Exiting outer loop if l1
-    if (l1) {
+    if (reached_stop_time_step) {
       break;
     }
 

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -14,7 +14,7 @@
 
 namespace output {
 
-// Field widths of the convergence table. The rows and the header use the same
+// Field widths of the history table. The rows and the header use the same
 // widths, so that they are vertically aligned. A value wider than its field
 // shifts the rest of the row rather than being truncated.
 constexpr int eq_width = 2;        // equation symbol
@@ -33,28 +33,14 @@ constexpr int iter_width = time_step_width + 4;
 // Number of digits printed after the decimal point in scientific notation.
 constexpr int number_precision = 3;
 
-// Number of characters in a row of the convergence table: the fields above,
+// Number of characters in a row of the history table: the fields above,
 // plus the ten spaces and the four brackets separating them.
 constexpr int table_width = eq_width + iter_width + 4 * number_width +
                             2 * db_width + ls_iter_width + pct_width + 14;
 
-/// @brief Prepares the output of svFSI to the standard output.
-///
-/// Modifies: timeP
-///
-/// \todo NOTE: This is not fully implemented.
-//
-void output_result(Simulation* simulation,  std::array<double,3>& timeP, const int co, const int iEq)
-{
-  #ifdef debug_output_result
-  DebugMsg dmsg(__func__, com_mod.cm.idcm());
-  dmsg.banner();
-  #endif
-
+void output_header(const Simulation *simulation, std::array<double, 3> &timeP) {
   auto& com_mod = simulation->com_mod;
-  auto& cm_mod = simulation->cm_mod;
-  auto& eq = com_mod.eq[iEq];
-  auto cTS = com_mod.cTS;
+  auto &cm_mod = simulation->cm_mod;
 
   // Writes to history file and optionally to cout.
   auto& logger = simulation->logger;
@@ -63,42 +49,60 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
     return;
   }
 
-  double tmp = utils::cput();
-  std::string sepLine(table_width,'-');
+  timeP[0] = utils::cput() - timeP[0];
+  timeP[1] = 0.0;
 
-  if (co == 1) {
-     timeP[0] = tmp - timeP[0];
-     timeP[1] = 0.0;
+  // The dash of the "N-i" title sits above the dash separating the time step
+  // from the nonlinear iteration.
+  std::ostringstream header;
+  header << " " << std::left << std::setw(eq_width) << "Eq"
+         << " " << std::setw(iter_width) << "     N-i"
+         << " " << std::right << std::setw(number_width) << "T"
+         << "  " << std::setw(db_width) << "dB"
+         << " " << std::setw(number_width) << "Ri/R1"
+         << " " << std::setw(number_width) << "Ri/R0"
+         << " " << std::setw(number_width) << "R/Ri"
+         << "   " << std::setw(ls_iter_width) << "lsIt"
+         << " " << std::setw(db_width) << "dB"
+         << " " << std::setw(pct_width) << "%t";
 
-     // The dash of the "N-i" title sits above the dash separating the time step
-     // from the nonlinear iteration.
-     std::ostringstream header;
-     header << " " << std::left << std::setw(eq_width) << "Eq"
-            << " " << std::setw(iter_width) << "     N-i"
-            << " " << std::right << std::setw(number_width) << "T"
-            << "  " << std::setw(db_width) << "dB"
-            << " " << std::setw(number_width) << "Ri/R1"
-            << " " << std::setw(number_width) << "Ri/R0"
-            << " " << std::setw(number_width) << "R/Ri"
-            << "   " << std::setw(ls_iter_width) << "lsIt"
-            << " " << std::setw(db_width) << "dB"
-            << " " << std::setw(pct_width) << "%t";
+  std::string sepLine(table_width, '-');
+  logger << sepLine << std::endl;
+  logger << header.str() << std::endl;
+  if (com_mod.nEq == 1) {
+    logger << sepLine << std::endl;
+  }
+}
 
-     logger << sepLine << std::endl;
-     logger << header.str() << std::endl;
-     if (com_mod.nEq == 1) {
-       logger << sepLine << std::endl;
-     }
-     return;
+void output_result(const Simulation *simulation, std::array<double, 3> &timeP,
+                   const bool save_results, const int iEq) {
+#ifdef debug_output_result
+  DebugMsg dmsg(__func__, com_mod.cm.idcm());
+  dmsg.banner();
+#endif
+
+  auto &com_mod = simulation->com_mod;
+  auto &cm_mod = simulation->cm_mod;
+  auto &eq = com_mod.eq[iEq];
+  auto cTS = com_mod.cTS;
+
+  // Writes to history file and optionally to cout.
+  auto &logger = simulation->logger;
+
+  if (com_mod.cm.slv(cm_mod)) {
+    return;
   }
 
+  double tmp = utils::cput();
+
   if ((com_mod.nEq > 1) && (iEq == 0) && (eq.itr == 1)) {
+    std::string sepLine(table_width, '-');
     logger << sepLine << std::endl;
   }
 
   // The time step and the nonlinear iteration, flagged with an 's' when the
   // results of this time step are written to a file.
-  const char* save_flag = (co == 3) ? "s" : "";
+  const char *save_flag = save_results ? "s" : "";
   std::ostringstream iter;
   iter << std::setw(time_step_width) << cTS << "-" << eq.itr << save_flag;
 

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -8,29 +8,35 @@
 #include "utils.h"
 
 #include <cstdio>
+#include <iomanip>
 #include <math.h>
+#include <sstream>
 
 namespace output {
 
-// Format of a row of the convergence table. The field widths accommodate a
-// two-character equation symbol, a six-digit time step, a two-digit nonlinear
-// iteration, a three-digit dB value with its sign and a five-digit linear
-// solver iteration count.
-constexpr const char* row_format =
-    " %-2s %-10s %10.3e %c%4d %10.3e %10.3e %10.3e%c %c%5d %4d %4d%c";
+// Field widths of the convergence table. The rows and the header use the same
+// widths, so that they are vertically aligned. A value wider than its field
+// shifts the rest of the row rather than being truncated.
+constexpr int eq_width = 2;        // equation symbol
+constexpr int time_step_width = 6; // time step
+constexpr int number_width = 10;   // numbers in scientific notation
+constexpr int db_width = 4;        // dB columns, three digits and their sign
+constexpr int ls_iter_width = 5;   // linear solver iterations
+constexpr int pct_width =
+    4; // percentage of the time spent in the linear solver
 
-// Format of the header of the convergence table. The field widths match those
-// of row_format, so that the header and the rows are vertically aligned.
-constexpr const char* header_format =
-    " %-2s %-10s %10s %c%4s %10s %10s %10s%c %c%5s %4s %4s";
+// Width of the time step and nonlinear iteration column: the time step, the
+// dash separating it from the two-digit nonlinear iteration, and the 's'
+// flagging a time step whose results are written to a file.
+constexpr int iter_width = time_step_width + 4;
 
-// Number of characters in a row of the convergence table.
-constexpr int table_width = 83;
+// Number of digits printed after the decimal point in scientific notation.
+constexpr int number_precision = 3;
 
-// Size of the buffers holding a row of the convergence table. Larger than
-// table_width, so that a value exceeding the width of its field is printed in
-// full rather than truncated.
-constexpr int row_buffer_size = 2*table_width;
+// Number of characters in a row of the convergence table: the fields above,
+// plus the ten spaces and the four brackets separating them.
+constexpr int table_width = eq_width + iter_width + 4 * number_width +
+                            2 * db_width + ls_iter_width + pct_width + 14;
 
 /// @brief Prepares the output of svFSI to the standard output.
 ///
@@ -57,7 +63,6 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
     return;
   }
 
-  int fid = 1;
   double tmp = utils::cput();
   std::string sepLine(table_width,'-');
 
@@ -65,14 +70,22 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
      timeP[0] = tmp - timeP[0];
      timeP[1] = 0.0;
 
-     // The dash of the "N-i" header sits above the dash separating the time
-     // step from the nonlinear iteration.
-     char header[row_buffer_size];
-     snprintf(header, sizeof(header), header_format, "Eq", "     N-i", "T", ' ', "dB",
-         "Ri/R1", "Ri/R0", "R/Ri", ' ', ' ', "lsIt", "dB", "%t");
+     // The dash of the "N-i" title sits above the dash separating the time step
+     // from the nonlinear iteration.
+     std::ostringstream header;
+     header << " " << std::left << std::setw(eq_width) << "Eq"
+            << " " << std::setw(iter_width) << "     N-i"
+            << " " << std::right << std::setw(number_width) << "T"
+            << "  " << std::setw(db_width) << "dB"
+            << " " << std::setw(number_width) << "Ri/R1"
+            << " " << std::setw(number_width) << "Ri/R0"
+            << " " << std::setw(number_width) << "R/Ri"
+            << "   " << std::setw(ls_iter_width) << "lsIt"
+            << " " << std::setw(db_width) << "dB"
+            << " " << std::setw(pct_width) << "%t";
 
      logger << sepLine << std::endl;
-     logger << header << std::endl;
+     logger << header.str() << std::endl;
      if (com_mod.nEq == 1) {
        logger << sepLine << std::endl;
      }
@@ -86,8 +99,8 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
   // The time step and the nonlinear iteration, flagged with an 's' when the
   // results of this time step are written to a file.
   const char* save_flag = (co == 3) ? "s" : "";
-  char iter_str[row_buffer_size];
-  snprintf(iter_str, sizeof(iter_str), "%6d-%d%s", cTS, eq.itr, save_flag);
+  std::ostringstream iter;
+  iter << std::setw(time_step_width) << cTS << "-" << eq.itr << save_flag;
 
   timeP[2] = tmp - timeP[0];
 
@@ -109,8 +122,8 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
 
   // The residuals are bracketed by '!' when the nonlinear residual has grown by
   // more than 20 dB.
-  const char nl_open  = (i > 20) ? '!' : '[';
-  const char nl_close = (i > 20) ? '!' : ']';
+  const char *nl_open = (i > 20) ? "!" : "[";
+  const char *nl_close = (i > 20) ? "!" : "]";
 
   double eps = std::numeric_limits<double>::epsilon();
 
@@ -127,20 +140,26 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
   }
 
   // Add a warning if the solution to the linear system did not converge.
-  const char ls_open  = eq.FSILS.RI.success ? '[' : '!';
-  const char ls_close = eq.FSILS.RI.success ? ']' : '!';
+  const char *ls_open = eq.FSILS.RI.success ? "[" : "!";
+  const char *ls_close = eq.FSILS.RI.success ? "]" : "!";
   std::string convergence_msg;
   if (!eq.FSILS.RI.success) {
     convergence_msg = "  WARNING: The linear system solution has not converged";
   }
 
-  char row[row_buffer_size];
-  snprintf(row, sizeof(row), row_format, eq.sym.c_str(), iter_str, timeP[2],
-      nl_open, i, tmp1, tmp, tmp2, nl_close,
-      ls_open, eq.FSILS.RI.itr, static_cast<int>(round(eq.FSILS.RI.dB)),
-      static_cast<int>(round(solver_pct)), ls_close);
+  std::ostringstream row;
+  row << " " << std::left << std::setw(eq_width) << eq.sym << " "
+      << std::setw(iter_width) << iter.str() << " " << std::right
+      << std::scientific << std::setprecision(number_precision)
+      << std::setw(number_width) << timeP[2] << " " << nl_open
+      << std::setw(db_width) << i << " " << std::setw(number_width) << tmp1
+      << " " << std::setw(number_width) << tmp << " " << std::setw(number_width)
+      << tmp2 << nl_close << " " << ls_open << std::setw(ls_iter_width)
+      << eq.FSILS.RI.itr << " " << std::setw(db_width)
+      << static_cast<int>(round(eq.FSILS.RI.dB)) << " " << std::setw(pct_width)
+      << static_cast<int>(round(solver_pct)) << ls_close;
 
-  logger << row << convergence_msg << std::endl;
+  logger << row.str() << convergence_msg << std::endl;
 
   // Print a warning message if the maximum number of nonlinear iterations has been exceeded.
   if (eq.itr > eq.maxItr) {

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -7,9 +7,30 @@
 #include "output.h"
 #include "utils.h"
 
+#include <cstdio>
 #include <math.h>
 
 namespace output {
+
+// Format of a row of the convergence table. The field widths accommodate a
+// two-character equation symbol, a six-digit time step, a two-digit nonlinear
+// iteration, a three-digit dB value with its sign and a five-digit linear
+// solver iteration count.
+constexpr const char* row_format =
+    " %-2s %-10s %10.3e %c%4d %10.3e %10.3e %10.3e%c %c%5d %4d %4d%c";
+
+// Format of the header of the convergence table. The field widths match those
+// of row_format, so that the header and the rows are vertically aligned.
+constexpr const char* header_format =
+    " %-2s %-10s %10s %c%4s %10s %10s %10s%c %c%5s %4s %4s";
+
+// Number of characters in a row of the convergence table.
+constexpr int table_width = 83;
+
+// Size of the buffers holding a row of the convergence table. Larger than
+// table_width, so that a value exceeding the width of its field is printed in
+// full rather than truncated.
+constexpr int row_buffer_size = 2*table_width;
 
 /// @brief Prepares the output of svFSI to the standard output.
 ///
@@ -38,18 +59,22 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
 
   int fid = 1;
   double tmp = utils::cput();
-  std::string sepLine(69,'-');
+  std::string sepLine(table_width,'-');
 
   if (co == 1) {
      timeP[0] = tmp - timeP[0];
      timeP[1] = 0.0;
+
+     // The dash of the "N-i" header sits above the dash separating the time
+     // step from the nonlinear iteration.
+     char header[row_buffer_size];
+     snprintf(header, sizeof(header), header_format, "Eq", "     N-i", "T", ' ', "dB",
+         "Ri/R1", "Ri/R0", "R/Ri", ' ', ' ', "lsIt", "dB", "%t");
+
      logger << sepLine << std::endl;
-     logger << " Eq     N-i     T       dB  Ri/R1   Ri/R0    R/Ri     lsIt   dB  %t" << std::endl;
-     //std::cout << sepLine << std::endl;
-     //std::cout << " Eq     N-i     T       dB  Ri/R1   Ri/R0    R/Ri     lsIt   dB  %t" << std::endl;
+     logger << header << std::endl;
      if (com_mod.nEq == 1) {
        logger << sepLine << std::endl;
-       //std::cout << sepLine << std::endl;
      }
      return;
   }
@@ -58,20 +83,13 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
     logger << sepLine << std::endl;
   }
 
-  std::string c1 = " ";
-  std::string c2 = " ";
+  // The time step and the nonlinear iteration, flagged with an 's' when the
+  // results of this time step are written to a file.
+  const char* save_flag = (co == 3) ? "s" : "";
+  char iter_str[row_buffer_size];
+  snprintf(iter_str, sizeof(iter_str), "%6d-%d%s", cTS, eq.itr, save_flag);
 
-  if (co == 3) {
-    c1 = "s";
-  }
-
-  // NS     1-2  3.82E1  [ -62 7.92E-4 7.92E-4 3.60E-4]  [   5  -15  23]
-  //-------------------
-  //
   timeP[2] = tmp - timeP[0];
-  char time_str[20];
-  sprintf(time_str, "%4.3e", timeP[2]);
-  std::string sOut = " " + eq.sym + " " + std::to_string(cTS) + "-" + std::to_string(eq.itr) + c1 + " " + time_str;
 
   int i;
   double tmp1 = 1.0;
@@ -89,22 +107,11 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
     i = static_cast<int>(20.0*log10(tmp1));
   }
 
-  if (i > 20) {
-    c1 = "!"; 
-    c2 = "!";
-  } else {
-    c1 = "["; 
-    c2 = "]";
-  }
+  // The residuals are bracketed by '!' when the nonlinear residual has grown by
+  // more than 20 dB.
+  const char nl_open  = (i > 20) ? '!' : '[';
+  const char nl_close = (i > 20) ? '!' : ']';
 
-  char norm1_str[20], norm2_str[20], norm3_str[20];
-  sprintf(norm1_str, "%4.3e", tmp);
-  sprintf(norm2_str, "%4.3e", tmp1);
-  sprintf(norm3_str, "%4.3e", tmp2);
-
-  // NS     1-2  3.82E1  [ -62 7.92E-4 7.92E-4 3.60E-4]  [   5  -15  23] 
-  //                       ----------------------------
-  sOut += "  " + c1 + std::to_string(i) + " " + norm2_str  + " " + norm1_str + " " + norm3_str + c2;
   double eps = std::numeric_limits<double>::epsilon();
 
   if (utils::is_zero(timeP[2],timeP[1])) {
@@ -113,35 +120,27 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
 
   // Percent of time in solver?
   //
-  tmp = 100.0 * eq.FSILS.RI.callD / (timeP[2] - timeP[1]);
+  double solver_pct = 100.0 * eq.FSILS.RI.callD / (timeP[2] - timeP[1]);
   timeP[1] = timeP[2];
-  if (fabs(tmp) > 100.0) {
-    tmp = 100.0;
+  if (fabs(solver_pct) > 100.0) {
+    solver_pct = 100.0;
   }
 
   // Add a warning if the solution to the linear system did not converge.
+  const char ls_open  = eq.FSILS.RI.success ? '[' : '!';
+  const char ls_close = eq.FSILS.RI.success ? ']' : '!';
   std::string convergence_msg;
-  if (eq.FSILS.RI.success) {
-    c1 = "[";
-    c2 = "]";
-  } else {
-    c1 = "!";
-    c2 = "!";
+  if (!eq.FSILS.RI.success) {
     convergence_msg = "  WARNING: The linear system solution has not converged";
   }
 
-  // NS     1-2  3.82E1  [ -62 7.92E-4 7.92E-4 3.60E-4]  [   5  -15  23] 
-  //                                                      -------------
-  auto db_str = std::to_string(static_cast<int>(round(eq.FSILS.RI.dB)));
-  auto calld_str = std::to_string(static_cast<int>(round(tmp)));
-  sOut += "  " + c1 + std::to_string(eq.FSILS.RI.itr) + " " + db_str + " " + calld_str + c2;
-  sOut += convergence_msg; 
+  char row[row_buffer_size];
+  snprintf(row, sizeof(row), row_format, eq.sym.c_str(), iter_str, timeP[2],
+      nl_open, i, tmp1, tmp, tmp2, nl_close,
+      ls_open, eq.FSILS.RI.itr, static_cast<int>(round(eq.FSILS.RI.dB)),
+      static_cast<int>(round(solver_pct)), ls_close);
 
-  if (com_mod.nEq > 1) {
-    logger << sOut << std::endl;
-  } else {
-    logger << sOut << std::endl;
-  }
+  logger << row << convergence_msg << std::endl;
 
   // Print a warning message if the maximum number of nonlinear iterations has been exceeded.
   if (eq.itr > eq.maxItr) {

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -79,15 +79,15 @@ void output_header(const Simulation *simulation, std::array<double, 3> &timeP) {
 
 void output_result(const Simulation *simulation, std::array<double, 3> &timeP,
                    const bool save_results, const int iEq) {
-#ifdef debug_output_result
-  DebugMsg dmsg(__func__, com_mod.cm.idcm());
-  dmsg.banner();
-#endif
-
   auto &com_mod = simulation->com_mod;
   auto &cm_mod = simulation->cm_mod;
   auto &eq = com_mod.eq[iEq];
   auto cTS = com_mod.cTS;
+
+#ifdef debug_output_result
+  DebugMsg dmsg(__func__, com_mod.cm.idcm());
+  dmsg.banner();
+#endif
 
   // Writes to history file and optionally to cout.
   auto &logger = simulation->logger;

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdio>
 #include <iomanip>
+#include <limits>
 #include <math.h>
 #include <sstream>
 

--- a/Code/Source/solver/output.cpp
+++ b/Code/Source/solver/output.cpp
@@ -14,16 +14,16 @@
 
 namespace output {
 
+namespace {
 // Field widths of the history table. The rows and the header use the same
 // widths, so that they are vertically aligned. A value wider than its field
 // shifts the rest of the row rather than being truncated.
-constexpr int eq_width = 2;        // equation symbol
-constexpr int time_step_width = 6; // time step
-constexpr int number_width = 10;   // numbers in scientific notation
-constexpr int db_width = 4;        // dB columns, three digits and their sign
-constexpr int ls_iter_width = 5;   // linear solver iterations
-constexpr int pct_width =
-    4; // percentage of the time spent in the linear solver
+constexpr int eq_width        = 2;  // equation symbol
+constexpr int time_step_width = 6;  // time step
+constexpr int number_width    = 10; // numbers in scientific notation
+constexpr int db_width        = 4;  // dB columns, three digits and their sign
+constexpr int ls_iter_width   = 5;  // linear solver iterations
+constexpr int pct_width       = 4;  // percentage of the time spent in the linear solver
 
 // Width of the time step and nonlinear iteration column: the time step, the
 // dash separating it from the two-digit nonlinear iteration, and the 's'
@@ -37,6 +37,10 @@ constexpr int number_precision = 3;
 // plus the ten spaces and the four brackets separating them.
 constexpr int table_width = eq_width + iter_width + 4 * number_width +
                             2 * db_width + ls_iter_width + pct_width + 14;
+
+// Separator line of the history table.
+std::string separator_line() { return std::string(table_width, '-'); }
+} // namespace
 
 void output_header(const Simulation *simulation, std::array<double, 3> &timeP) {
   auto& com_mod = simulation->com_mod;
@@ -66,11 +70,10 @@ void output_header(const Simulation *simulation, std::array<double, 3> &timeP) {
          << " " << std::setw(db_width) << "dB"
          << " " << std::setw(pct_width) << "%t";
 
-  std::string sepLine(table_width, '-');
-  logger << sepLine << std::endl;
+  logger << separator_line() << std::endl;
   logger << header.str() << std::endl;
   if (com_mod.nEq == 1) {
-    logger << sepLine << std::endl;
+    logger << separator_line() << std::endl;
   }
 }
 
@@ -96,8 +99,7 @@ void output_result(const Simulation *simulation, std::array<double, 3> &timeP,
   double tmp = utils::cput();
 
   if ((com_mod.nEq > 1) && (iEq == 0) && (eq.itr == 1)) {
-    std::string sepLine(table_width, '-');
-    logger << sepLine << std::endl;
+    logger << separator_line() << std::endl;
   }
 
   // The time step and the nonlinear iteration, flagged with an 's' when the

--- a/Code/Source/solver/output.h
+++ b/Code/Source/solver/output.h
@@ -12,7 +12,38 @@
 
 namespace output {
 
-void output_result(Simulation* simulation,  std::array<double,3>& timeP, const int co, const int iEq);
+/**
+ * @brief Write the header of the history table to the standard output and to
+ * the history file.
+ *
+ * The elapsed time reported by the rows of the table is measured from the
+ * moment this function is called.
+ *
+ * @param[in] simulation Simulation whose logger the header is written to.
+ * @param[in,out] timeP Timers of the history table: the elapsed time of the
+ *   runs preceding this one, replaced by the instant the elapsed time is
+ *   measured from, the elapsed time of the previous row and the elapsed time of
+ *   the current row.
+ */
+void output_header(const Simulation *simulation, std::array<double, 3> &timeP);
+
+/**
+ * @brief Write one row of the history table to the standard output and to the
+ * history file.
+ *
+ * The row reports the residuals and the linear solver statistics of the
+ * nonlinear iteration that has just been completed.
+ *
+ * @param[in] simulation Simulation whose logger the row is written to.
+ * @param[in,out] timeP Timers of the history table: the instant the elapsed
+ *   time is measured from, the elapsed time of the previous row, which is
+ *   replaced by the one of this row, and the elapsed time of this row.
+ * @param[in] save_results True if the results of this time step are written to
+ *   a VTU file, which flags the row with an 's'.
+ * @param[in] iEq Index of the equation the row reports on.
+ */
+void output_result(const Simulation *simulation, std::array<double, 3> &timeP,
+                   const bool save_results, const int iEq);
 
 void read_restart_header(ComMod& com_mod, std::array<int,7>& tStamp, double& timeP, std::ifstream& restart_file);
 


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

Fixes #615 about incorrect reporting of iterations in multi-equation simulations. Also adds some cosmetic improvements to the history table. See the issue for details.

This has no effect on calculations, but only on convergence history reporting.

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
