### PR TITLE
Fix GMRES early termination result

### DIFF
--- a/Code/Source/linear_solver/gmres.cpp
+++ b/Code/Source/linear_solver/gmres.cpp
@@ -340,6 +340,7 @@ void gmres_s(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
     ls.callD = std::numeric_limits<double>::epsilon();
     ls.dB = 0.0;
     ls.success = true;
+    R = X;
     return; 
   }
 
@@ -494,6 +495,7 @@ void gmres_v(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
     ls.callD = std::numeric_limits<double>::epsilon();
     ls.dB = 0.0;
     ls.success = true;
+    R = X;
     return; 
   }
 

--- a/Code/Source/linear_solver/gmres.cpp
+++ b/Code/Source/linear_solver/gmres.cpp
@@ -26,9 +26,8 @@ namespace gmres {
 
 namespace {
 
-void bc_pre(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_subLsType& ls, const int dof,
-    const int mynNo, const int nNo)
-{
+void bc_pre(fsi_linear_solver::FSILS_lhsType &lhs, const int dof,
+            const int mynNo, const int nNo) {
   int nsd = dof - 1;
   Array<double> v(nsd,nNo);
 

--- a/Code/Source/linear_solver/gmres.cpp
+++ b/Code/Source/linear_solver/gmres.cpp
@@ -318,10 +318,6 @@ void gmres_s(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
   dmsg << "ls.relTol: " << ls.relTol;
   #endif
 
-  Array<double> h(ls.sD+1,ls.sD);
-  Array<double> u(nNo,ls.sD+1);
-  Vector<double> X(nNo), y(ls.sD), c(ls.sD), s(ls.sD), err(ls.sD+1);
-
   ls.callD = fsi_linear_solver::fsils_cpu_t();
   ls.success = false;
   double eps = norm::fsi_ls_norms(mynNo, lhs.commu, R);
@@ -339,9 +335,13 @@ void gmres_s(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
     ls.callD = std::numeric_limits<double>::epsilon();
     ls.dB = 0.0;
     ls.success = true;
-    R = X;
-    return; 
+    R = 0.0;
+    return;
   }
+
+  Array<double> h(ls.sD + 1, ls.sD);
+  Array<double> u(nNo, ls.sD + 1);
+  Vector<double> X(nNo), y(ls.sD), c(ls.sD), s(ls.sD), err(ls.sD + 1);
 
   for (int l = 0; l < ls.mItr; l++) {
     #ifdef debug_gmres_s
@@ -470,11 +470,6 @@ void gmres_v(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
   dmsg << "ls.relTol: " << ls.relTol;
   #endif
 
-  Array<double> h(ls.sD+1,ls.sD), X(dof,nNo);
-  Array3<double> u(dof,nNo,ls.sD+1);
-  Array<double> unCondU(dof,nNo);
-  Vector<double> y(ls.sD), c(ls.sD), s(ls.sD), err(ls.sD+1);
-
   ls.callD = fsi_linear_solver::fsils_cpu_t();
   ls.success = false;
   double eps = norm::fsi_ls_normv(dof, mynNo, lhs.commu, R);
@@ -488,15 +483,20 @@ void gmres_v(fsi_linear_solver::FSILS_lhsType& lhs, fsi_linear_solver::FSILS_sub
   dmsg << "eps: " << eps;
   #endif
 
-  bc_pre(lhs, ls, dof, mynNo, nNo);
+  bc_pre(lhs, dof, mynNo, nNo);
 
   if (ls.iNorm <= ls.absTol) {
     ls.callD = std::numeric_limits<double>::epsilon();
     ls.dB = 0.0;
     ls.success = true;
-    R = X;
+    R = 0.0;
     return; 
   }
+
+  Array<double> h(ls.sD + 1, ls.sD), X(dof, nNo);
+  Array3<double> u(dof, nNo, ls.sD + 1);
+  Array<double> unCondU(dof, nNo);
+  Vector<double> y(ls.sD), c(ls.sD), s(ls.sD), err(ls.sD + 1);
 
   for (int l = 0; l < ls.mItr; l++) {
     #ifdef debug_gmres_v

--- a/tests/cases/fluid/driven_cavity_2d_porous/result_002.vtu
+++ b/tests/cases/fluid/driven_cavity_2d_porous/result_002.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3599f021860914ac2ed3b1be3214205b8aa54ab06ab7ccb97519871e6673bfe2
-size 684013
+oid sha256:e4c88d7e8b91a6203d9e0bd40de13423de4ad37b272b0a05c4c1b95f2fcedd74
+size 686189


### PR DESCRIPTION
Fixes #623.

## Current situation

`gmres_s` and `gmres_v` use the argument `Vector<double> &R` as both input (the system's right hand side vector) and output (the system's solution upon convergence). If the functions reach the for loop for the actual GMRES iterations, once that loop is over, they set `R = X`, and everything is fine.

However, if the termination-with-no-iterations condition is triggered (that is, if the initial guess for the solution is already within the tolerance), the assignment `R = X` is never executed, and the functions just return.

The caller expects `R` to contain the solution, but it still contains the right hand side instead, which is incorrect.

## Release Notes 

1. Fixes the issue by setting `R = X` before the early return in `gmres_s` and `gmres_v`.
2. Regenerates reference solution for the test `fluid/driven_cavity_2d_porous`, which exhibited solution drift during nonlinear iterations with zero linear iterations (see [this comment](https://github.com/SimVascular/svMultiPhysics/issues/623#issuecomment-5454200428) for details).

## Documentation

There are no user-facing changes.

## Testing

The test suite passes (up to changing the reference solution of one test as per release note 2 above).

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
